### PR TITLE
Add a nixpkgs dependency that other repos can follow

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1707163378,
+        "narHash": "sha256-oz+BzUDwtyircjjxv9aPYOS5gobxLCjD2il+gb/bCRo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e2ffefe304d941bb98989847944f3b58e0adcdd5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e2ffefe304d941bb98989847944f3b58e0adcdd5",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,10 @@
 {
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/e2ffefe304d941bb98989847944f3b58e0adcdd5";
+  };
+
   description = "Pure Nix flake utility functions used in other RV repos";
-  outputs = { self }: {
+  outputs = { self, nixpkgs }: {
     lib.check-submodules = pkgs: dependencies:
       let
         hashes = with builtins;


### PR DESCRIPTION
This pin matches the version of Nixpkgs currently used in the LLVM backend (as it's the newest, and therefore the bottlenecking version).

I will follow this up with PRs that update the various backends and K to properly follow this input; once everything is set up we can think about getting updates propagated automatically.