### PR TITLE
Add workaround to patch sources for Pyk apps post-merge

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
     lib.mkPykAppSrc = {
       src,
       cleaner ? ({src} : src)
-    } : nixpkgs.stdenv.mkDerivation {
+    } : stdenv.mkDerivation {
       name = "pyk-app-src";
       src = cleaner { inherit src; };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,11 @@
 {
   description = "Pure Nix flake utility functions used in other RV repos";
   outputs = { self }: {
+    lib.mkPykAppSrc = {
+      src,
+      cleaner ? ({src} : src)
+    } : src;
+
     lib.check-submodules = pkgs: dependencies:
       let
         hashes = with builtins;

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
     lib.mkPykAppSrc = {
       src,
       cleaner ? ({src} : src)
-    } : stdenv.mkDerivation {
+    } : nixpkgs.stdenv.mkDerivation {
       name = "pyk-app-src";
       src = cleaner { inherit src; };
 

--- a/flake.nix
+++ b/flake.nix
@@ -7,9 +7,10 @@
 
   outputs = { self, nixpkgs }: {
     lib.mkPykAppSrc = {
+      pkgs,
       src,
       cleaner ? ({src} : src)
-    } : nixpkgs.stdenv.mkDerivation {
+    } : pkgs.stdenv.mkDerivation {
       name = "pyk-app-src";
       src = cleaner { inherit src; };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Pure Nix flake utility functions used in other RV repos";
   outputs = { self }: {
-    lib.mkPykAppSrc = {
+    lib.mkPykAppSrc = pkgs: {
       src,
       cleaner ? ({src} : src)
     } : src;

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,25 @@
 {
   description = "Pure Nix flake utility functions used in other RV repos";
   outputs = { self }: {
-    lib.mkPykAppSrc = pkgs: {
+    lib.mkPykAppSrc = {
       src,
       cleaner ? ({src} : src)
-    } : src;
+    } : nixpkgs.stdenv.mkDerivation {
+      name = "pyk-app-src";
+      src = cleaner { inherit src; };
+
+      dontBuild = true;
+
+      patchPhase = ''
+        substituteInPlace pyproject.toml \
+          --replace-fail ', subdirectory = "pyk"' ""
+      '';
+
+      installPhase = ''
+        mkdir -p $out/
+        cp -R * $out/
+      '';
+    };
 
     lib.check-submodules = pkgs: dependencies:
       let


### PR DESCRIPTION
There's an issue in Poetry2Nix whereby the `subdirectory` key for git dependencies is not stripped when the project file is patched; this means that the nix integration generates an invalid project file that fails schema validation.

This should probably be fixed in Poetry2Nix upstream, but we can work around the issue by defining a derivation that performs the required patching step on a project file affected by the issue.

I have tested this change locally against the C semantics and have verified that it fixes the issue; I have also ensured that pulling the version as implemented in this PR from the rv-utils flake input works as well.