### PR TITLE
Generalise to allow for different subdirectories

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,18 +10,18 @@
     mkSubdirectoryAppSrc = {
       pkgs,
       src,
-      subdirectory,
+      subdirectories,
       cleaner ? ({src} : src)
     } : pkgs.stdenv.mkDerivation {
-      name = "${subdirectory}-app-src";
+      name = "subdirs-app-src";
       src = cleaner { inherit src; };
 
       dontBuild = true;
 
-      patchPhase = ''
+      patchPhase = pkgs.lib.strings.concatMapStringsSep " " (subdir: ''
         substituteInPlace pyproject.toml \
-          --replace-fail ', subdirectory = "${subdirectory}"' ""
-      '';
+          --replace-fail ', subdirectory = "${subdir}"' ""
+      '') subdirectories;
 
       installPhase = ''
         mkdir -p $out/
@@ -38,7 +38,7 @@
       cleaner ? ({src} : src)
     } : mkSubdirectoryAppSrc {
       inherit pkgs src cleaner;
-      subdirectory = "pyk";
+      subdirectories = [ "pyk" ];
     };
 
     lib.check-submodules = pkgs: dependencies:

--- a/flake.nix
+++ b/flake.nix
@@ -5,26 +5,40 @@
 
   description = "Pure Nix flake utility functions used in other RV repos";
 
-  outputs = { self, nixpkgs }: {
-    lib.mkPykAppSrc = {
+  outputs = { self, nixpkgs }: 
+  let
+    mkSubdirectoryAppSrc = {
       pkgs,
       src,
+      subdirectory,
       cleaner ? ({src} : src)
     } : pkgs.stdenv.mkDerivation {
-      name = "pyk-app-src";
+      name = "${subdirectory}-app-src";
       src = cleaner { inherit src; };
 
       dontBuild = true;
 
       patchPhase = ''
         substituteInPlace pyproject.toml \
-          --replace-fail ', subdirectory = "pyk"' ""
+          --replace-fail ', subdirectory = "${subdirectory}"' ""
       '';
 
       installPhase = ''
         mkdir -p $out/
         cp -R * $out/
       '';
+    };
+  in
+  {
+    lib.mkSubdirectoryAppSrc = mkSubdirectoryAppSrc;
+
+    lib.mkPykAppSrc = {
+      pkgs,
+      src,
+      cleaner ? ({src} : src)
+    } : mkSubdirectoryAppSrc {
+      inherit pkgs src cleaner;
+      subdirectory = "pyk";
     };
 
     lib.check-submodules = pkgs: dependencies:


### PR DESCRIPTION
I realised on looking at the MX semantics that the subdirectory / git versioning pattern that breaks Poetry2Nix appears for more cases than just Pyk, so we need to generalise the fix for it here into a more reusable function.